### PR TITLE
[fix][client]Add support to invalidate client OAuth2 tokens

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Authentication.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Authentication.java
@@ -53,6 +53,16 @@ public interface Authentication extends Closeable, Serializable {
     }
 
     /**
+     * Invalidates cached authentication data.
+     *
+     * @throws PulsarClientException
+     *             any other error
+     */
+    default void invalidateAuthData() throws PulsarClientException {
+        throw new UnsupportedAuthenticationException("Method not implemented!");
+    }
+
+    /**
      * Get/Create an authentication data provider which provides the data that this client will be sent to the broker.
      * Some authentication method need to auth between each client channel. So it need the broker, who it will talk to.
      *

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -943,6 +943,13 @@ public class PulsarClientException extends IOException {
         }
     }
 
+   public static class TooFrequentTokenRefreshException extends PulsarClientException{
+        public TooFrequentTokenRefreshException(String msg) {
+            super(msg);
+        }
+    }
+
+
     // wrap an exception to enriching more info messages.
     public static Throwable wrap(Throwable t, String msg) {
         msg += "\n" + t.getMessage();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2Test.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2Test.java
@@ -22,8 +22,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -36,6 +35,7 @@ import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.DefaultMetadataResolver;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenResult;
 import org.testng.annotations.BeforeMethod;
@@ -130,6 +130,64 @@ public class AuthenticationOAuth2Test {
         data = this.auth.getAuthData();
         verify(this.flow, times(2)).authenticate();
         assertEquals(data.getCommandData(), tr.getAccessToken());
+    }
+
+    @Test
+    // Test happy path for invalidating authData
+    public void testSuccessfulInvalidateAuthData() throws Exception {
+        AuthenticationDataProvider data;
+        TokenResult tokenResult0 = TokenResult.builder().accessToken(TEST_ACCESS_TOKEN).expiresIn(TEST_EXPIRES_IN).build();
+        doReturn(tokenResult0).when(this.flow).authenticate();
+        data = this.auth.getAuthData();
+        // validates the authentication before invalidation is successful
+        verify(this.flow, times(1)).authenticate();
+        assertEquals(data.getCommandData(), tokenResult0.getAccessToken());
+
+        this.auth.invalidateAuthData();
+        // validates the invalidation is successful
+        assertEquals(this.auth.cachedToken, null);
+
+        TokenResult tokenResult1 = TokenResult.builder().accessToken(TEST_ACCESS_TOKEN).expiresIn(TEST_EXPIRES_IN).build();
+        doReturn(tokenResult1).when(this.flow).authenticate();
+        data = this.auth.getAuthData();
+        // validates getAuthData called authenticate and fetched a different token
+        verify(this.flow, times(1)).authenticate();
+        assertNotEquals(data.getCommandData(), tokenResult0.getAccessToken());
+        assertEquals(data.getCommandData(), tokenResult1.getAccessToken());
+    }
+
+    @Test
+    // Test too frequent authData invalidation
+    public void testTooFrequentInvalidateAuthData() throws Exception {
+        this.auth.invalidateAuthData();
+        TokenResult tokenResult0 = TokenResult.builder().accessToken(TEST_ACCESS_TOKEN).expiresIn(TEST_EXPIRES_IN).build();
+        doReturn(tokenResult0).when(this.flow).authenticate();
+        this.auth.getAuthData();
+        // validates getAuthData after invalidation calls authenticate
+        verify(this.flow, times(1)).authenticate();
+
+        // validates the second token invalidation fails due to this occurring within 5 minutes than the previous
+        // and checks the token is the same
+        assertThrows(
+                PulsarClientException.TooFrequentTokenRefreshException.class,
+                () -> this.auth.invalidateAuthData()
+        );
+        doReturn(
+                TokenResult.builder().accessToken(TEST_ACCESS_TOKEN).expiresIn(TEST_EXPIRES_IN).build()
+        ).when(this.flow).authenticate();
+        AuthenticationDataProvider data = this.auth.getAuthData();
+        verify(this.flow, times(0)).authenticate();
+        assertEquals(data.getCommandData(), tokenResult0.getAccessToken());
+
+        // validates token invalidation passes after 5 minutes
+        clock.advance(Duration.ofMinutes(5));
+        TokenResult tokenResult1 = TokenResult.builder().accessToken(TEST_ACCESS_TOKEN).expiresIn(TEST_EXPIRES_IN).build();
+        doReturn(tokenResult1).when(this.flow).authenticate();
+        this.auth.invalidateAuthData();
+        data = this.auth.getAuthData();
+        verify(this.flow, times(1)).authenticate();
+        assertNotEquals(data.getCommandData(), tokenResult0.getAccessToken());
+        assertEquals(data.getCommandData(), tokenResult1.getAccessToken());
     }
 
     @Test


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #20107

<!-- or this PR is one task of an issue -->

<!-- If the PR belongs to a PIP, please add the PIP link here -->

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/wiki/proposals/PIP.md -->

### Motivation

This attempts to add support for OAuth2 token invalidation on the client side, that could be useful in case of key-pair rotation on the server-side. The changes also try preventing the client from invalidating its tokens too often (only once in 5 minutes is allowed), in order to minimise the surface of a possible DDoS attack to the authentication endpoint. The logic limiting the invalidation rate could be refactored, for example we could implement some form of [exponential backoff algorithm](https://en.wikipedia.org/wiki/Exponential_backoff).

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

```
mvn install -Pcore-modules,-main -DskipTests -rf
mvn test -Dtest=AuthenticationOAuth2Test#testSuccessfulInvalidateAuthData,AuthenticationOAuth2Test#testTooFrequentInvalidateAuthData -f pulsar-client
```

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/MMirelli/pulsar/pull/3

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
