### PR TITLE
[improve][test] Implement broker integration test with entry metadata interceptors enabled

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/bookkeeper/BrokerInstallWithEntryMetadataInterceptorsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/bookkeeper/BrokerInstallWithEntryMetadataInterceptorsTest.java
@@ -21,6 +21,8 @@ import static org.testng.AssertJUnit.assertEquals;
  */
 @Slf4j
 public class BrokerInstallWithEntryMetadataInterceptorsTest extends PulsarClusterTestBase {
+    private static final String PREFIX = "PULSAR_PREFIX_";
+
     @BeforeClass(alwaysRun = true)
     @Override
     public final void setupCluster() throws Exception {
@@ -29,11 +31,12 @@ public class BrokerInstallWithEntryMetadataInterceptorsTest extends PulsarCluste
         final String clusterName = Stream.of(this.getClass().getSimpleName(), randomName(5))
                 .filter(s -> !s.isEmpty())
                 .collect(joining("-"));
-        brokerEnvs.put("exposingBrokerEntryMetadataToClientEnabled", "true");
-        brokerEnvs.put("brokerEntryMetadataInterceptors", "org.apache.pulsar.common.intercept.AppendBrokerTimestampMetadataInterceptor");
+        brokerEnvs.put(PREFIX + "exposingBrokerEntryMetadataToClientEnabled", "true");
+        brokerEnvs.put(PREFIX + "brokerEntryMetadataInterceptors", "org.apache.pulsar.common.intercept.AppendBrokerTimestampMetadataInterceptor");
         PulsarClusterSpec spec = PulsarClusterSpec.builder()
                 .numBookies(2)
                 .numBrokers(1)
+                .brokerEnvs(brokerEnvs)
                 .clusterName(clusterName)
                 .build();
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/bookkeeper/BrokerInstallWithEntryMetadataInterceptorsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/bookkeeper/BrokerInstallWithEntryMetadataInterceptorsTest.java
@@ -14,6 +14,11 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.joining;
 import static org.testng.AssertJUnit.assertEquals;
 
+/***
+ * Test that verifies that regression in BookKeeper 4.16.0 is fixed.
+ *
+ * Anti-regression test for issue https://github.com/apache/pulsar/issues/20091.
+ */
 @Slf4j
 public class BrokerInstallWithEntryMetadataInterceptorsTest extends PulsarClusterTestBase {
     @BeforeClass(alwaysRun = true)
@@ -48,13 +53,13 @@ public class BrokerInstallWithEntryMetadataInterceptorsTest extends PulsarCluste
     }
 
     @Test
-    public void testBookieHttpServerIsRunning() throws Exception {
+    public void testBrokerHttpServerIsRunning() throws Exception {
         ContainerExecResult result = pulsarCluster.getAnyBroker().execCmd(
                 PulsarCluster.CURL,
                 "-X",
                 "GET",
-                "http://localhost:6650/admin/v2/brokers/health");
+                "http://localhost:8080/admin/v2/brokers/health");
         assertEquals(result.getExitCode(), 0);
-        assertEquals(result.getStdout(), "ok\n");
+        assertEquals("ok", result.getStdout());
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/bookkeeper/BrokerInstallWithEntryMetadataInterceptorsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/bookkeeper/BrokerInstallWithEntryMetadataInterceptorsTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.tests.integration.bookkeeper;
 
 import lombok.extern.slf4j.Slf4j;

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/bookkeeper/BrokerInstallWithEntryMetadataInterceptorsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/bookkeeper/BrokerInstallWithEntryMetadataInterceptorsTest.java
@@ -1,0 +1,60 @@
+package org.apache.pulsar.tests.integration.bookkeeper;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
+import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
+import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
+import org.apache.pulsar.tests.integration.topologies.PulsarClusterTestBase;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.joining;
+import static org.testng.AssertJUnit.assertEquals;
+
+@Slf4j
+public class BrokerInstallWithEntryMetadataInterceptorsTest extends PulsarClusterTestBase {
+    @BeforeClass(alwaysRun = true)
+    @Override
+    public final void setupCluster() throws Exception {
+        incrementSetupNumber();
+
+        final String clusterName = Stream.of(this.getClass().getSimpleName(), randomName(5))
+                .filter(s -> !s.isEmpty())
+                .collect(joining("-"));
+        brokerEnvs.put("exposingBrokerEntryMetadataToClientEnabled", "true");
+        brokerEnvs.put("brokerEntryMetadataInterceptors", "org.apache.pulsar.common.intercept.AppendBrokerTimestampMetadataInterceptor");
+        PulsarClusterSpec spec = PulsarClusterSpec.builder()
+                .numBookies(2)
+                .numBrokers(1)
+                .clusterName(clusterName)
+                .build();
+
+        log.info("Setting up cluster {} with {} bookies, {} brokers",
+                spec.clusterName(), spec.numBookies(), spec.numBrokers());
+
+        pulsarCluster = PulsarCluster.forSpec(spec);
+        pulsarCluster.start();
+
+        log.info("Cluster {} is setup", spec.clusterName());
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    public final void tearDownCluster() throws Exception {
+        super.tearDownCluster();
+    }
+
+    @Test
+    public void testBookieHttpServerIsRunning() throws Exception {
+        ContainerExecResult result = pulsarCluster.getAnyBroker().execCmd(
+                PulsarCluster.CURL,
+                "-X",
+                "GET",
+                "http://localhost:6650/admin/v2/brokers/health");
+        assertEquals(result.getExitCode(), 0);
+        assertEquals(result.getStdout(), "ok\n");
+    }
+}


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes [20091](https://github.com/apache/pulsar/issues/20091)

<!-- If the PR belongs to a PIP, please add the PIP link here -->

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/wiki/proposals/PIP.md -->

### Motivation

This adds an important regression test preventing the error reported by https://lists.apache.org/thread/f2fhvyx202xzxbho909j430h63yvwjlo. 

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [X] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

*(example:)*
  1. `PULSAR_TEST_IMAGE_NAME=massimilianomirelli/pulsar-test-latest-version:bad-20091 mvn -f tests/pom.xml test -Dtest=BrokerInstallWithEntryMetadataInterceptorsTest -DintegrationTests` -> expected: fail
  2. `mvn -f tests/pom.xml test -Dtest=BrokerInstallWithEntryMetadataInterceptorsTest -DintegrationTests` -> expected: pass

I verified that 1. fails outputting the error as per the description posted by @michaeljmarshall on the mailing list:

```
2023-05-25T06:16:10,753+0000 [broker-topic-workers-OrderedExecutor-5-0] ERROR org.apache.pulsar.common.protocol.Commands - [PersistentSubscription{topic=persistent://pulsar/BrokerInstallWithEntryMetadataInterceptorsTest-gyqkh/pulsar-broker-0:8080/healthcheck, name=healthCheck-3acbc80e-dd09-4ade-ba2c-11f786ec2f05}] [-1] Failed to parse message metadata
java.lang.IndexOutOfBoundsException: readerIndex(139) + length(2) exceeds writerIndex(139): UnpooledDuplicatedByteBuf(ridx: 139, widx: 139, cap: 139, unwrapped: CompositeByteBuf(ridx: 139, widx: 139, cap: 139, components=2))
	at io.netty.buffer.AbstractByteBuf.checkReadableBytes0(AbstractByteBuf.java:1442) ~[io.netty-netty-buffer-4.1.89.Final.jar:4.1.89.Final]
	at io.netty.buffer.AbstractByteBuf.readShort(AbstractByteBuf.java:749) ~[io.netty-netty-buffer-4.1.89.Final.jar:4.1.89.Final]
	at org.apache.pulsar.common.protocol.Commands.skipBrokerEntryMetadataIfExist(Commands.java:1692) ~[org.apache.pulsar-pulsar-common-3.1.0-SNAPSHOT.jar:3.1.0-SNAPSHOT]
	at org.apache.pulsar.common.protocol.Commands.parseMessageMetadata(Commands.java:452) ~[org.apache.pulsar-pulsar-common-3.1.0-SNAPSHOT.jar:3.1.0-SNAPSHOT]
	at org.apache.pulsar.common.protocol.Commands.parseMessageMetadata(Commands.java:445) ~[org.apache.pulsar-pulsar-common-3.1.0-SNAPSHOT.jar:3.1.0-SNAPSHOT]
	at org.apache.pulsar.common.protocol.Commands.peekMessageMetadata(Commands.java:1899) ~[org.apache.pulsar-pulsar-common-3.1.0-SNAPSHOT.jar:3.1.0-SNAPSHOT]
	at org.apache.pulsar.common.protocol.Commands.peekAndCopyMessageMetadata(Commands.java:1918) ~[org.apache.pulsar-pulsar-common-3.1.0-SNAPSHOT.jar:3.1.0-SNAPSHOT]
	at org.apache.pulsar.broker.service.AbstractBaseDispatcher.filterEntriesForConsumer(AbstractBaseDispatcher.java:142) ~[org.apache.pulsar-pulsar-broker-3.0.0.jar:3.0.0]
	at org.apache.pulsar.broker.service.AbstractBaseDispatcher.filterEntriesForConsumer(AbstractBaseDispatcher.java:100) ~[org.apache.pulsar-pulsar-broker-3.0.0.jar:3.0.0]
	at org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer.internalReadEntriesComplete(PersistentDispatcherSingleActiveConsumer.java:210) ~[org.apache.pulsar-pulsar-broker-3.0.0.jar:3.0.0]
	at org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer.lambda$readEntriesComplete$1(PersistentDispatcherSingleActiveConsumer.java:151) ~[org.apache.pulsar-pulsar-broker-3.0.0.jar:3.0.0]
	at org.apache.bookkeeper.common.util.SingleThreadExecutor.safeRunTask(SingleThreadExecutor.java:137) ~[org.apache.bookkeeper-bookkeeper-common-4.16.0.jar:4.16.0]
	at org.apache.bookkeeper.common.util.SingleThreadExecutor.run(SingleThreadExecutor.java:113) ~[org.apache.bookkeeper-bookkeeper-common-4.16.0.jar:4.16.0]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.89.Final.jar:4.1.89.Final]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

I built `massimilianomirelli/pulsar-test-latest-version:bad-20091` using `apachepulsar/pulsar-test-latest-version:latest` as base image and replacing the broker and bookkeeper libs with [the ones from Release 3.0.0 Candidate 1](https://dist.apache.org/repos/dist/dev/pulsar/pulsar-3.0.0-candidate-1/apache-pulsar-3.0.0-bin.tar.gz).

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
